### PR TITLE
Features to extract farm-level information and MD input file to create FAST.Farm cases.

### DIFF
--- a/famodel/project.py
+++ b/famodel/project.py
@@ -4318,24 +4318,24 @@ class Project():
         yaw_init = np.zeros((1, len(self.platformList.items())))
         for _, pf in self.platformList.items():
             x, y, z   = pf.body.r6[0], pf.body.r6[1], pf.body.r6[2]
-            phi       = np.degrees(pf.phi)  # float((90 - np.degrees(pf.phi)) % 360)  # Converting FAD's rotational convention (0deg N, +ve CW) into FF's rotational convention (0deg E, +ve CCW)
-            phi       = (phi + 180) % 360 - 180  # Shift range to -180 to 180
+            phi_deg       = np.degrees(pf.phi)  # float((90 - np.degrees(pf.phi)) % 360)  # Converting FAD's rotational convention (0deg N, +ve CW) into FF's rotational convention (0deg E, +ve CCW)
+            phi_deg       = (phi_deg + 180) % 360 - 180  # Shift range to -180 to 180
             for att in pf.attachments.values():
                 if isinstance(att['obj'],Turbine):
                     D    = 240   # att['obj'].D         (assuming 15MW)
                     zhub = att['obj'].dd['hHub']
                 
             wts[i] = {
-                'x': x, 'y': y, 'z': z, 'phi': phi, 'D': D, 'zhub': zhub, 
+                'x': x, 'y': y, 'z': z, 'phi_deg': phi_deg, 'D': D, 'zhub': zhub, 
                 'cmax': cmax, 'fmax': fmax, 'Cmeander': Cmeander
                 }
-            yaw_init[0, i] = -phi
+            yaw_init[0, i] = -phi_deg
             i += 1
 
         # store farm-level wind turbine information
         self.wts = wts
 
-        return wts, yaw_init
+        return wts, yaw_init  
     
     def FFarmCompatibleMDOutput(self, filename, unrotateTurbines=True, renameBody=True, removeBody=True, MDoptionsDict={}):
         '''
@@ -4365,7 +4365,7 @@ class Project():
         # Unrotate turbines if needed
         if unrotateTurbines:
             if self.wts:
-                phiV = [wt['phi'] for wt in self.wts.values()]  # [180, 0] # to unrotate the platforms when unloading MoorDyn
+                phiV = [wt['phi_deg'] for wt in self.wts.values()]  # to unrotate the platforms when unloading MoorDyn
             else:
                 raise ValueError("wts is empty. Please run project.extractFarmInfo first before extracting MoorDyn")
         else:


### PR DESCRIPTION
Following the updates suggested in [#42](https://github.com/NREL/MoorPy/pull/42) PR in MoorPy and in [#40](https://github.com/OpenFAST/openfast_toolbox/pull/40) PR in Openfast toolbox, This PR introduces two features:

**Extract farm-level information for FFarm Integration**
1 - A new method in project class called 'extractFarmInfo' that generates a dictionary table of farm-level information needed to create FFarm cases to run FFarm simulations
2 - Angles are adjusted based on variation in rotational convention between FAM and FFarm.
3 - General input parameters are optional and default values are given.

**FFarmCompatibleMDOutput**
1) Outputs FFarm-compatible MD output with the orientation of the different platforms subtracted from them so that FFarm can apply the rotation in ED.
2) The method also renames bodies into 'Turbinex' with x being the number of the turbine. 
3) It also removes bodies listed by default in MoorDyn (So platform mass is not accounted twice, once in MD and once in FAST.Farm).
4) The method also can accept MD options dictionary for users to experiment with varying options which can help with dynamic relaxation investigation

An example of a 2-turbine wind farm extracted to FFarm is shown below, where red lines are MD mooring lines (before rotations) and white lines are mooring lines after applying rotations inside FAST.Farm:

<img width="737" alt="image" src="https://github.com/user-attachments/assets/c18bb413-ff12-45a4-840f-ecadaa4ee9e7" />
