### PR TITLE
Adding seabed disturbance calculations for the Mooring class:

### DIFF
--- a/famodel/mooring/mooring.py
+++ b/famodel/mooring/mooring.py
@@ -132,6 +132,7 @@ class Mooring(Edge):
         # Dictionaries for additional information
         self.envelopes = {}  # 2D motion envelope, buffers, etc.
         self.loads = {}
+        self.disturbedSeabedArea = 0
         self.safety_factors = {}
         self.reliability = {}
         self.cost = {}


### PR DESCRIPTION
- Mooring has an attribute called disturbedSeabedArea that is initialized with zero.
- When calling arrayWatchCircle in the project class, if the option is activated to calculate seabed disturbance, it will be populated.
- The computation of seabed area disturbed is approximate and not exact. It assumes the attached platform has a circular watch circle and assumes a perfectly triangular disturbance shape around the anchor.