### PR TITLE
Adding Resetting Array Origin to Mid-Platform:

### DIFF
--- a/famodel/mooring/mooring.py
+++ b/famodel/mooring/mooring.py
@@ -198,7 +198,7 @@ class Mooring(Edge):
         r_center : list or nested list
             The x, y, z coordinates of the platform(s) (undisplaced) [m]. If shared mooring, must be a list of lists, with the
             coordinates for each platform connection. In this case, end A platform connection is the first entry and end B 
-            platform connection is the second entry.
+            platform connection is the second entry. If not given, r_center will be populated from what self is attached to.
         heading : float
             The absolute heading compass direction of the mooring line from end B
             [deg or rad] depending on degrees parameter (True or False). Must account for the platform heading as well.
@@ -227,11 +227,15 @@ class Mooring(Edge):
         # heading 2D unit vector
         u = np.array([np.cos(phi), np.sin(phi)])
         
-        if self.shared == 1:
-            r_centerB = np.array(r_center)[1]
-            r_centerA = np.array(r_center)[0]
+        if np.any(r_center):
+            if self.shared == 1:
+                r_centerA = np.array(r_center)[0]
+                r_centerB = np.array(r_center)[1]
+            else:
+                r_centerB = np.array(r_center)
         else:
-            r_centerB = np.array(r_center)
+            r_centerA = self.attached_to[0].r
+            r_centerB = self.attached_to[1].r
             
         # create fairlead radius list for end A and end B if needed
         if not rad_fair:

--- a/famodel/platform/platform.py
+++ b/famodel/platform/platform.py
@@ -64,8 +64,10 @@ class Platform(Node):
     def setPosition(self, r, heading=None, degrees=False,project=None):
         '''
         Set the position/orientation of the platform as well as the associated
-        anchor points.
+        anchor points. 
         
+        "Note: must only be used for a platform that's only attached with anchored lines"
+
         Parameters
         ----------
         r : list


### PR DESCRIPTION
This will help with TurbSim and FFarm integration as farm needs to have an origin at the center of the farm. The resetArrayCenter can accept centering the array based on all platforms or only those carrying FOWTs. The function will change bathymetries, boundaries, platform locations, and everything associated with the platforms.