### PR TITLE
A new feature to enable plot2d to show the line depth in 2D.

### DIFF
--- a/famodel/project.py
+++ b/famodel/project.py
@@ -2153,7 +2153,7 @@ class Project():
             platform.r[1] = platform.body.r6[1]
         
     
-    def plot2d(self, ax=None, plot_seabed=False,draw_soil=False,plot_bathymetry=True, plot_boundary=True, bare=False, axis_equal=True,save=False,**kwargs):
+    def plot2d(self, ax=None, plot_seabed=False,draw_soil=False,plot_bathymetry=True, plot_boundary=True, color_lineDepth=False, bare=False, axis_equal=True,save=False,**kwargs):
         '''Plot aspects of the Project object in matplotlib in 3D.
         
         TODO - harmonize a lot of the seabed stuff with MoorPy System.plot...
@@ -2182,6 +2182,7 @@ class Project():
         bath_levels = kwargs.get('bath_levels', None)
         show_legend = kwargs.get('show_legend', True)
         
+        max_line_depth = kwargs.get('max_line_depth', None)  # max depth for line coloring if color_lineDepth is True
         
         # if axes not passed in, make a new figure
         if ax == None:
@@ -2250,6 +2251,17 @@ class Project():
                     ax.fill(env['x'], env['y'], edgecolor=edgecolor, facecolor='none', linestyle='dashed', lw=0.8, label='Platform Envelope')
         
         if plot_moorings:
+            depth_cmap_settings = None
+            if color_lineDepth:
+                if max_line_depth is None:
+                    bath_depth = True
+                if plot_bathymetry:
+                    raise ValueError("Cannot use depth-based line coloring with plot_bathymetry=True. Disable bathymetry to avoid confusion.")
+                depth_cmap_settings = {
+                    "cmap": "Blues",
+                    "vmin": max_line_depth if max_line_depth else -np.max(self.grid_depth),
+                    "vmax": 0
+                }            
             for mooring in self.mooringList.values():
                 for name, env in mooring.envelopes.items():
                     #if 'shape' in env:  # if there's a shapely object
@@ -2284,16 +2296,27 @@ class Project():
                     
                 if mooring.ss:
                     mooring.ss.drawLine2d(0, ax, color="self", endpoints=False, 
-                                          Xuvec=[1,0,0], Yuvec=[0,1,0],label=labs)  
+                                          Xuvec=[1,0,0], Yuvec=[0,1,0], depth_cmap_settings=depth_cmap_settings, label=labs)  
                 elif mooring.parallels:
                     for i,line in enumerate(lineList):
                         line.drawLine2d(0, ax, color="self",
-                                        Xuvec=[1,0,0], Yuvec=[0,1,0],label=labs[i])
+                                        Xuvec=[1,0,0], Yuvec=[0,1,0], depth_cmap_settings=depth_cmap_settings, label=labs[i])
 
                 else: # simple line plot
                     ax.plot([mooring.rA[0], mooring.rB[0]], 
                             [mooring.rA[1], mooring.rB[1]], 'k', lw=0.5, label='Mooring Line')
-                
+
+        # ---- Add colorbar for line depth ----
+        if depth_cmap_settings is not None and not bare:
+            import matplotlib.cm as cm
+            import matplotlib.colors as mcolors
+            sm = cm.ScalarMappable(cmap=cm.get_cmap(depth_cmap_settings["cmap"]),
+                                norm=mcolors.Normalize(vmin=depth_cmap_settings["vmin"],
+                                                        vmax=depth_cmap_settings["vmax"]))
+            sm.set_array([])
+            cbar = plt.colorbar(sm, ax=ax, fraction=0.04)
+            cbar.set_label("Line Depth (m)")  
+                          
         if plot_anchors:
             for anchor in self.anchorList.values():
                 ax.plot(anchor.r[0],anchor.r[1], 'mo',ms=2, label='Anchor')


### PR DESCRIPTION
This feature requires the updates in drawLine2d in subsystem.py in MoorPy to be integrated. These changes are provided in this PR: NREL/MoorPy#58

- The user can provide a set value of maximum depth to show the most transparent part of the line. By default, this is set to the water depth. But sometimes, we might be interested in limiting the depth to the first 200m for instance or to show the depth of which it can be affected by marine growth (e.g., -170m). This is added as a variable in kwargs called max_line_depth.

Here's an example of showing the first 170m of the water column:
<img width="782" height="691" alt="Screenshot 2025-10-05 at 4 52 24 PM" src="https://github.com/user-attachments/assets/785f5101-96d1-4e60-9646-86102fa301b1" />
This pull request adds the ability to color mooring lines by depth in the `plot2d` method of the `Project` class, including support for a colorbar and related options. The main changes introduce a new `color_lineDepth` argument, handle color mapping and validation, and update the plotting logic accordingly.

**Enhancements to 2D Plotting of Moorings:**

* Added a `color_lineDepth` argument to the `plot2d` method in `project.py`, allowing users to color mooring lines based on their depth.
* Included a `max_line_depth` option in the plotting kwargs to control the depth range for color mapping.
* Implemented logic to set up depth-based color mapping for mooring lines, including error handling to prevent conflicts with bathymetry plotting.
* Updated calls to `drawLine2d` for mooring lines to pass the new `depth_cmap_settings` parameter, enabling the actual depth-based coloring.

**User Interface Improvements:**

* Added a colorbar to the plot when depth-based coloring is enabled and not in bare mode, providing a visual reference for line depths.